### PR TITLE
Combined Ivanjh and judgefish improvements

### DIFF
--- a/config/gcode_macro.cfg
+++ b/config/gcode_macro.cfg
@@ -174,8 +174,30 @@ gcode:
 #    Z_TILT_ADJUST
     G29
     G0 Z50 F600
-    G0 X0 Y0  F6000
-    
+#    G0 X0 Y0  F6000
+
+# Move to X center
+    G1 X97 F15000
+# Move back near wiper
+    G1 Y243 F15000
+# Engage wiper
+    G1 Y254 F800
+
+# Chamber very slow to heat compared to extruder
+# Set
+#    M104 S{hotendtemp}
+#    M141 S{chambertemp}
+
+# Set+Wait
+    M191 S{chambertemp}
+    M109 S{hotendtemp}
+
+# Move away from wiper
+    G1 Y240 F800
+# Move away to left
+    G1 X0 F15000
+# Move up to front
+    G1 Y0 F15000
 
     M109 S{hotendtemp}
     M141 S{chambertemp}    


### PR DESCRIPTION
-Changed warmup location to be over the wiper bin to compensate for leakage on build plate (from ivanjh)
-Slow down extruder speed during cleaning to avoid skipping when using 0.2mm nozzle. (Should be more dynamic from actually used nozzle instead) (from judgefish)
-Slow down eddy probing slightly but do only one measurement. (from judgefish)
-Speed up piezo probing to ensure trigging but do more measurements. (from judgefish)
-Longer retract for piezo but shorter for eddy. (from judgefish)
-Speed up movement during bed_mesh (from judgefish)
-Added some debug messages to know what macros are run. (from judgefish)
-Tested On My Personal Q1 Pro, Verified Firmware installs without issue,  Changes are QOL but are highly recommended (From Me Geek1243)